### PR TITLE
Allow the generation of .bin files thru plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ then add embark-solc to the plugins section in ```embark.json```:
 
 ```Json
   "plugins": {
-    "embark-solc": {}
+    "embark-solc": {
+      "outputBinary": false
+    }
   }
 ```
+
+- `outputBinary` can be specified to generate a .bin file that contains the binary of the contracts in hex. Default value is `false`.
 
 Requirements
 ======

--- a/index.js
+++ b/index.js
@@ -7,6 +7,6 @@ module.exports = (embark) => {
 		if(!contractFiles || !contractFiles.length) {
 			return cb();
 		}
-		Compiler.compileSolc(embark.logger, contractFiles, cb);
+		Compiler.compileSolc(embark, contractFiles, cb);
 	}
 };

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -1,6 +1,6 @@
 const async = require('async');
-const path = require('path');
 const shelljs = require('shelljs');
+const fs = require('fs');
 
 function compileSolcContract(logger, filename, callback) {
   shelljs.exec(`solc --optimize --combined-json abi,bin,bin-runtime,compact-format,hashes,interface,metadata ${filename}`,
@@ -22,10 +22,14 @@ function compileSolcContract(logger, filename, callback) {
   });
 }
 
-function compileSolc(logger, contractFiles, cb) {
+function compileSolc(embark, contractFiles, cb) {
   if (!contractFiles || !contractFiles.length) {
     return cb();
   }
+
+  const logger = embark.logger;
+  const outputBinary = embark.pluginConfig.outputBinary;
+  const outputDir = embark.config.buildDir + embark.config.contractDirectories[0];
 
   const solc = shelljs.which('solc'); 
   if (!solc) {
@@ -35,6 +39,7 @@ function compileSolc(logger, contractFiles, cb) {
   }
   
   logger.info("compiling solidity contracts with command line solc...");
+  
   let compiled_object = {};
   async.each(contractFiles,
     function (file, fileCb) {
@@ -59,6 +64,13 @@ function compileSolc(logger, contractFiles, cb) {
           compiled_object[className].functionHashes = contract.hashes;
           compiled_object[className].abiDefinition = JSON.parse(contract.abi);
           compiled_object[className].filename = fileName;
+
+          if(outputBinary){
+            fs.writeFile(outputDir + className + ".bin", contract.bin, (err) => {
+              if (err) logger.error(err);
+            });
+          }
+
         }
 
         fileCb();

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -1,6 +1,7 @@
 const async = require('async');
 const shelljs = require('shelljs');
 const fs = require('fs');
+const path = require('path');
 
 function compileSolcContract(logger, filename, callback) {
   shelljs.exec(`solc --optimize --combined-json abi,bin,bin-runtime,compact-format,hashes,interface,metadata ${filename}`,
@@ -64,8 +65,6 @@ function compileSolc(embark, contractFiles, cb) {
           compiled_object[className].functionHashes = contract.hashes;
           compiled_object[className].abiDefinition = JSON.parse(contract.abi);
           compiled_object[className].filename = fileName;
-
-          
         }
 
         fileCb();
@@ -73,20 +72,17 @@ function compileSolc(embark, contractFiles, cb) {
     },
     function (err) {
       cb(err, compiled_object);  
-      
-      embark.events.on("outputDone", function() {
-        if(outputBinary){
+      if(outputBinary){
+        embark.events.on("outputDone", function() {
           Object.keys(compiled_object).map(function(className, index) {
-            fs.writeFile(outputDir + className + ".bin", compiled_object[className].bin, (err) => {
+            fs.writeFile(path.join(outputDir, className + ".bin"), compiled_object[className].bin, (err) => {
               if (err) {
                 logger.error("Error writing binary file: " + JSON.stringify(err));
               }
             });
           });
-        }
-      });
-
-
+        });
+      }
     });
 }
 

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -65,19 +65,28 @@ function compileSolc(embark, contractFiles, cb) {
           compiled_object[className].abiDefinition = JSON.parse(contract.abi);
           compiled_object[className].filename = fileName;
 
-          if(outputBinary){
-            fs.writeFile(outputDir + className + ".bin", contract.bin, (err) => {
-              if (err) logger.error(err);
-            });
-          }
-
+          
         }
 
         fileCb();
       });
     },
     function (err) {
-      cb(err, compiled_object);
+      cb(err, compiled_object);  
+      
+      embark.events.on("outputDone", function() {
+        if(outputBinary){
+          Object.keys(compiled_object).map(function(className, index) {
+            fs.writeFile(outputDir + className + ".bin", compiled_object[className].bin, (err) => {
+              if (err) {
+                logger.error("Error writing binary file: " + JSON.stringify(err));
+              }
+            });
+          });
+        }
+      });
+
+
     });
 }
 


### PR DESCRIPTION
An user may be able to specify if he wants generated a .bin file containing the raw hex from a compiled contract adding the following code to `embark.json` 
```
"embark-solc": {
      "outputBinary": true
}
 ```
 