### PR TITLE
Add directories inside contracts/ to list of allowed paths for solc

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -3,8 +3,10 @@ const shelljs = require('shelljs');
 const fs = require('fs');
 const path = require('path');
 
-function compileSolcContract(logger, filename, callback) {
-  shelljs.exec(`solc --optimize --combined-json abi,bin,bin-runtime,compact-format,hashes,interface,metadata ${filename}`,
+function compileSolcContract(logger, filename, allowedDirectories, callback) {
+  const command = `solc --optimize --combined-json abi,bin,bin-runtime,compact-format,hashes,interface,metadata --allow-paths ${allowedDirectories.join(',')} ${filename}`;
+  console.log(command);
+  shelljs.exec(command,
      {silent: true}, (code, stdout, stderr) => {
 
     if (stderr) {
@@ -40,11 +42,13 @@ function compileSolc(embark, contractFiles, cb) {
   }
   
   logger.info("compiling solidity contracts with command line solc...");
-  
+
+  const allowedDirectories = contractFiles.map((contractFile) => path.dirname(path.join(process.cwd(), contractFile.path)));
+
   let compiled_object = {};
   async.each(contractFiles,
     function (file, fileCb) {
-      compileSolcContract(logger, file.filename, (err, compileString) => {
+      compileSolcContract(logger, file.filename, allowedDirectories, (err, compileString) => {
         if (err) {
           return fileCb(err);
         }

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -59,16 +59,20 @@ function compileSolc(embark, contractFiles, cb) {
 
         for (let contractFile in json.contracts) {
           let className = contractFile.substr( contractFile.indexOf(":") + 1);
-          let fileName = contractFile.substr(0, contractFile.indexOf(":"));
+          let filename = contractFile.substr(0, contractFile.indexOf(":"));
           
           let contract = json.contracts[contractFile];
-          
+          if(compiled_object[className] && compiled_object[className].filename != filename){
+            logger.warn(`Duplicated contract '${className}' found. Using '${compiled_object[className].filename}' instead of '${file.filename}'`);
+            continue;
+          }
+
           compiled_object[className] = {};
           compiled_object[className].code = contract.bin
           compiled_object[className].runtimeBytecode = contract["bin-runtime"];
           compiled_object[className].functionHashes = contract.hashes;
           compiled_object[className].abiDefinition = JSON.parse(contract.abi);
-          compiled_object[className].filename = fileName;
+          compiled_object[className].filename = filename;
         }
 
         fileCb();

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -5,7 +5,6 @@ const path = require('path');
 
 function compileSolcContract(logger, filename, allowedDirectories, callback) {
   const command = `solc --optimize --combined-json abi,bin,bin-runtime,compact-format,hashes,interface,metadata --allow-paths ${allowedDirectories.join(',')} ${filename}`;
-  console.log(command);
   shelljs.exec(command,
      {silent: true}, (code, stdout, stderr) => {
 
@@ -43,7 +42,8 @@ function compileSolc(embark, contractFiles, cb) {
   
   logger.info("compiling solidity contracts with command line solc...");
 
-  const allowedDirectories = contractFiles.map((contractFile) => path.dirname(path.join(process.cwd(), contractFile.path)));
+  const allowedDirectories = contractFiles.map((contractFile) => path.dirname(path.join(process.cwd(), contractFile.path)))
+                                          .filter((x, i, a) => a.indexOf(x) == i);
 
   let compiled_object = {};
   async.each(contractFiles,


### PR DESCRIPTION
Assume you have the following contracts and directories
```
contracts/directoryAlfa/myContract.sol
contracts/directoryBeta/otherContract.sol
```

myContract.sol:
```pragma solidity ^0.4.23;
contract MyContract {
      uint public v;
}
```

otherContract.sol:
```pragma solidity ^0.4.23;
import "../directoryAlfa/myContract.sol";
contract OtherContract is MyContract {
     uint public w;
}
```

Under the current published version it will faill when compiling `OtherContract` indicating that `./contracts/directoryAlfa/` is not in the allowed list of directories. This PR will allow compilation of contracts that import files from another directories, because it will add these into the `--allow-paths` option of solc

