### PR TITLE
Add options arg and do not exit on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const Compiler = require("./lib/Compiler");
 
 module.exports = (embark) => {
 	embark.registerCompiler('.sol', compileSolc);
-	function compileSolc(contractFiles, cb) {
+	function compileSolc(contractFiles, options, cb) {
 		if(!contractFiles || !contractFiles.length) {
 			return cb();
 		}

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -35,9 +35,9 @@ function compileSolc(embark, contractFiles, cb) {
 
   const solc = shelljs.which('solc'); 
   if (!solc) {
-    logger.warn('solc is not installed on your machine');
+    logger.error('solc is not installed on your machine');
     logger.info('You can install it by following the instructions on: http://solidity.readthedocs.io/en/latest/installing-solidity.html');
-    process.exit();
+    return cb('Compiler not installed');
   }
   
   logger.info("compiling solidity contracts with command line solc...");

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "plugin",
     "contracts",
     "ethereum",
-	"embark"
+    "embark"
   ],
   "author": "Richard Ramos",
   "license": "ISC",


### PR DESCRIPTION
Options field was added in 3.2 (only publish when 3.2 is released)
Removed the `process.exit()` as it the dashboard, it prevented from seeing the message.