### PR TITLE
lib/Compiler: Switch to standard JSON input Solidity API.

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -3,32 +3,58 @@ const shelljs = require('shelljs');
 const fs = require('fs');
 const path = require('path');
 
-function compileSolcContract(logger, file, allowedDirectories, callback) {
-  var compile = function() {
-    var remappings = file.importRemappings.map((mapping) => `${path.dirname(file.filename)}:${mapping.prefix}=${mapping.target}`);
-    var filename = file.pluginPath ? path.join(file.pluginPath, file.filename) : file.filename;
-    var command = `solc --optimize --combined-json abi,bin,bin-runtime,compact-format,hashes,interface,metadata --allow-paths ${allowedDirectories.join(',')} ${remappings.join(' ')} ${filename}`;
+function compileSolcContract(logger, file, allowedDirectories, solcConfig, callback) {
+  let input = {};
+  const remappings = file.importRemappings.map((mapping) => `${path.dirname(file.filename)}:${mapping.prefix}=${mapping.target}`);
+  const filename = file.pluginPath ? path.join(file.pluginPath, file.filename) : file.filename;
+  input[filename] = {content: shelljs.cat(filename).replace(/\r\n/g, '\n'), path: filename};
 
-    shelljs.exec(command,
-      {silent: true}, (code, stdout, stderr) => {
-
-      if (stderr) {
-        logger.warn(stderr);
+  let jsonObj =  {
+    language: 'Solidity',
+    sources: input,
+    settings: {
+      optimizer: {
+        enabled: solcConfig['optimize'],
+        runs: solcConfig['optimize-runs']
+      },
+      outputSelection: {
+        '*': {
+          '': ['ast'],
+          '*': [
+            'abi',
+            'devdoc',
+            'evm.bytecode',
+            'evm.deployedBytecode',
+            'evm.gasEstimates',
+            'evm.legacyAssembly',
+            'evm.methodIdentifiers',
+            'metadata',
+            'userdoc'
+          ]
+        }
       }
-
-      if (code !== 0) {
-        return callback(`solc exited with error code ${code}`);
-      }
-
-      if (!stdout) {
-        return callback('Execution returned nothing');
-      }
-
-      callback(null, stdout.replace(/\n/g, ''));
-    });
+    }
   };
 
-  file.content(compile);
+  const command = `solc --standard-json --allow-paths ${allowedDirectories.join(',')} ${remappings.join(' ')}`;
+
+  shelljs.ShellString(JSON.stringify(jsonObj)).exec(command,
+    {silent: true}, (code, stdout, stderr) => {
+
+   if (stderr) {
+     logger.warn(stderr);
+   }
+
+   if (code !== 0) {
+     return callback(`solc exited with error code ${code}`);
+   }
+
+   if (!stdout) {
+     return callback('Execution returned nothing');
+   }
+
+   callback(null, stdout.replace(/\n/g, ''));
+ });
 }
 
 function compileSolc(embark, contractFiles, cb) {
@@ -39,6 +65,7 @@ function compileSolc(embark, contractFiles, cb) {
   const logger = embark.logger;
   const outputBinary = embark.pluginConfig.outputBinary;
   const outputDir = embark.config.buildDir + embark.config.contractDirectories[0];
+  const solcConfig = embark.config.embarkConfig.options.solc;
 
   const solc = shelljs.which('solc'); 
   if (!solc) {
@@ -49,44 +76,43 @@ function compileSolc(embark, contractFiles, cb) {
   
   logger.info("compiling solidity contracts with command line solc...");
 
-  const allowedDirectories = contractFiles.map((contractFile) => path.dirname(path.join(process.cwd(), contractFile.path)))
-                                          .filter((x, i, a) => a.indexOf(x) == i);
+  const allowedDirectories = contractFiles.map((contractFile) => path.dirname(contractFile.path))
+                                         .filter((x, i, a) => a.indexOf(x) == i);
   
   let compiled_object = {};
   async.each(contractFiles,
-    function (file, fileCb) {
-      compileSolcContract(logger, file, allowedDirectories, (err, compileString) => {
+    function (file, callback) {
+      compileSolcContract(logger, file, allowedDirectories, solcConfig, (err, compileString) => {
         if (err) {
-          return fileCb(err);
+          return callback(err);
         }
 
-        let jsonStart = compileString.indexOf("\"contracts\":{");
+        let json = JSON.parse(compileString).contracts;
 
-        let json = JSON.parse(compileString.substr(jsonStart - 1));
+        for (let contractFile in json) {
+          for (let contractName in json[contractFile]) {
+            let contract = json[contractFile][contractName];
 
-        for (let contractFile in json.contracts) {
-          let className = contractFile.substr(contractFile.indexOf(":") + 1);
-          let filename = contractFile.substr(0, contractFile.indexOf(":"));
-          
-          let contract = json.contracts[contractFile];
-          if(compiled_object[className] && compiled_object[className].filename != filename){
-            logger.warn(`Duplicated contract '${className}' found. Using '${compiled_object[className].filename}' instead of '${file.filename}'`);
-            continue;
+            const className = contractName;
+            const filename = contractFile;
+
+            compiled_object[className] = {};
+            compiled_object[className].code = contract.evm.bytecode.object;
+            compiled_object[className].runtimeBytecode = contract.evm.deployedBytecode.object;
+            compiled_object[className].realRuntimeBytecode = contract.evm.deployedBytecode.object.slice(0, -68);
+            compiled_object[className].swarmHash = contract.evm.deployedBytecode.object.slice(-68).slice(0, 64);
+            compiled_object[className].gasEstimates = contract.evm.gasEstimates;
+            compiled_object[className].functionHashes = contract.evm.methodIdentifiers;
+            compiled_object[className].abiDefinition = contract.abi;
+            compiled_object[className].filename = filename;
           }
-
-          compiled_object[className] = {};
-          compiled_object[className].code = contract.bin;
-          compiled_object[className].runtimeBytecode = contract["bin-runtime"];
-          compiled_object[className].functionHashes = contract.hashes;
-          compiled_object[className].abiDefinition = JSON.parse(contract.abi);
-          compiled_object[className].filename = filename;
         }
 
-        fileCb();
+        callback();
       });
     },
     function (err) {
-      cb(err, compiled_object);  
+      cb(err, compiled_object);
       if(outputBinary){
         embark.events.on("outputDone", function() {
           Object.keys(compiled_object).map(function(className, _index) {


### PR DESCRIPTION
The change to standard JSON input is needed to align Solidity
compiler options for Embark and Embark-solc plugin.

The background of the change is to fix bug:

https://github.com/embark-framework/embark/issues/942

where the contract profiler was working for solcjs but not working with Embark-solc plugin
using binary solc release. The root cause was missing gasEstimate data in the compiled
contract JSON output data. The gasEstimate data is not available due to different compiler options
available for command line --combined-json and standard JSON input.

Gas estimation is command line solc compiler can be triggered by invoking command
line --gas option, the gas estimate is then printed out on the standard output but does not
end up in the Solidity compiler JSON output.

The solution to fix the problem is to use standard JSON input both for solcjs and solc compilers.
Additionally this change  aligns Embark and Embark-solc to use the same compiler options.

References: https://solidity.readthedocs.io/en/v0.4.25/using-the-compiler.html

Fixes: https://github.com/embark-framework/embark/issues/942