### PR TITLE
feat(@embark/embark-solc): Support recursively remapping imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,31 +6,26 @@ module.exports = (embark) => {
   if (embark.config.embarkConfig.versions.solc) {
     const versionPromise = new Promise(function(resolve, reject) {
       // Check solc version
-      Compiler.getSolcVersion(embark.logger, (err, version) => {
-        if (err) {
-          embark.logger.error(err);
-          embark.logger.error("Error getting solc's version. Will default back to Embark's compiler");
-          return reject(err);
-        }
-        if (semver.lt(version, embark.config.embarkConfig.versions.solc)) {
-          embark.logger.warn(`Current version of solc lower than version in embark.json`);
-          embark.logger.warn(`Current: ${version} | Wanted: ${embark.config.embarkConfig.versions.solc}`);
-          embark.logger.warn('Will default back to Embark\'s compiler');
-          return reject(new Error('Bad version'));
-        }
-        resolve();
-      });
+      
     });
 
     embark.registerCompiler('.sol', (contractFiles, options, cb) => {
       if (!contractFiles || !contractFiles.length) {
         return cb();
       }
-      versionPromise.then(() => {
-        Compiler.compileSolc(embark, contractFiles, embark.config.contractDirectories, cb);
-      }).catch(_e => {
-        // Need to default to Embark's compiler
-        cb(null, false);
+      Compiler.getSolcVersion(embark.logger, (err, version) => {
+        if (err) {
+          embark.logger.error(err);
+          embark.logger.error("Error getting solc's version. Will default back to Embark's compiler");
+          return cb(null, false);
+        }
+        if (semver.lt(version, embark.config.embarkConfig.versions.solc)) {
+          embark.logger.warn(`Current version of solc lower than version in embark.json`);
+          embark.logger.warn(`Current: ${version} | Wanted: ${embark.config.embarkConfig.versions.solc}`);
+          embark.logger.warn('Will default back to Embark\'s compiler');
+          return cb(null, false);
+        }
+        Compiler.compileSolc(embark, contractFiles, embark.config.contractDirectories, options, cb);
       });
     });
 

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -42,7 +42,7 @@ function getSolcVersion(logger, callback) {
   });
 }
 
-function compileSolc(embark, contractFiles, contractDirectories, callback) {
+function compileSolc(embark, contractFiles, contractDirectories, options, callback) {
   if (!contractFiles || !contractFiles.length) {
     return callback();
   }
@@ -52,7 +52,7 @@ function compileSolc(embark, contractFiles, contractDirectories, callback) {
   const outputDir = embark.config.buildDir + embark.config.contractDirectories[0];
   const solcConfig = embark.config.embarkConfig.options.solc;
 
-  let allowedDirectories;
+  let allowedDirectories = [];
   const remappings = [];
   const compilationSettings = {
     language: 'Solidity',
@@ -94,43 +94,31 @@ function compileSolc(embark, contractFiles, contractDirectories, callback) {
       next();
     },
 
-    function getAllowedDirectories(next) {
-      allowedDirectories = contractFiles.map((contractFile) => path.join(process.cwd(), path.dirname(contractFile.path) + '/'))
-        .filter((x, i, a) => a.indexOf(x) === i);
-      // Add default contract paths
-      allowedDirectories.push(
-        path.join(process.cwd(), 'node_modules/'),
-        path.join(process.cwd(), '.embark/contracts/')
-      );
-      next();
-    },
-
     function getContentAndRemappings(next) {
       async.each(contractFiles, (file, eachCb) => {
-        file.content(content => {
-          file.parsedContent = content;
+        file.prepareForCompilation(options.isCoverage).then((content) => {
+          // add contract directory and all it's recusrive import direcotries to allowed directories
+          let dir = path.dirname(file.path);
+          if (!allowedDirectories.includes(dir)) allowedDirectories.push(dir);
 
-          const newRemappings = file.importRemappings.map((mapping) => `${mapping.prefix}=${mapping.target}`);
-          newRemappings.forEach(newRemapping => {
-            if (!remappings.includes(newRemapping)) {
-              remappings.push(newRemapping);
+          file.importRemappings.forEach((importRemapping) => {
+            dir = path.dirname(importRemapping.target);
+            if (!allowedDirectories.includes(dir)) allowedDirectories.push(dir);
+
+            const remapping = `${importRemapping.prefix}=${importRemapping.target}`;
+            if (!remappings.includes(remapping)) {
+              remappings.push(remapping);
             }
           });
 
-          eachCb();
-        });
-      }, next);
-    },
+          compilationSettings.sources[file.path] = {
+            content: content.replace(/\r\n/g, '\n'),
+            path: file.path
+          };
 
-    function getCompilationSettings(next) {
-      contractFiles.forEach(file => {
-        const filename = file.pluginPath ? path.join(file.pluginPath, file.filename) : file.filename;
-        compilationSettings.sources[filename] = {
-          content: file.parsedContent.replace(/\r\n/g, '\n'),
-          path: filename
-        };
-      });
-      next();
+          eachCb();
+        }).catch(eachCb);
+      }, next);
     },
 
     function compile(next) {


### PR DESCRIPTION
Changes include:
- Before compilation, for each contract file being compiled, recursively remaps the contract's imports.
- Allowed directories for compilation updated based on the remapped import paths for the contract file.
- Support for code coverage flag.
- Fix for unhandled promise rejection when attempting to use an insufficient version of solc.

Works with changes introduced in `embark` PR https://github.com/embark-framework/embark/pull/1286