### PR TITLE
fix(@embark-solc): Fix unknown key “path” error

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,6 @@ const semver = require('semver');
 
 module.exports = (embark) => {
   if (embark.config.embarkConfig.versions.solc) {
-    const versionPromise = new Promise(function(resolve, reject) {
-      // Check solc version
-      
-    });
-
     embark.registerCompiler('.sol', (contractFiles, options, cb) => {
       if (!contractFiles || !contractFiles.length) {
         return cb();

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -112,8 +112,7 @@ function compileSolc(embark, contractFiles, contractDirectories, options, callba
           });
 
           compilationSettings.sources[file.path] = {
-            content: content.replace(/\r\n/g, '\n'),
-            path: file.path
+            content: content.replace(/\r\n/g, '\n')
           };
 
           eachCb();


### PR DESCRIPTION
A rebase of @emizzle's fix on top of master

Compilation error `Unknown key “path”` was present when using Solidity 0.5.x. This PR removes the path property from the compilation sources as it is not needed.