### PR TITLE
fix(embark-solc): fix original filename not being the right one

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -159,7 +159,6 @@ function compileSolc(embark, contractFiles, contractDirectories, options, callba
         for (let contractName in contracts[contractFile]) {
           let contract = contracts[contractFile][contractName];
           let filename = contractFile;
-          const originalFilename = filename;
           for (let directory of contractDirectories) {
             let match = new RegExp("^" + directory);
             filename = filename.replace(match, '');
@@ -180,8 +179,12 @@ function compileSolc(embark, contractFiles, contractDirectories, options, callba
           compiledObject[className].gasEstimates = contract.evm.gasEstimates;
           compiledObject[className].functionHashes = contract.evm.methodIdentifiers;
           compiledObject[className].abiDefinition = contract.abi;
+          compiledObject[className].userdoc = contract.userdoc;
           compiledObject[className].filename = filename;
-          compiledObject[className].originalFilename = originalFilename;
+          const normalized = path.normalize(filename);
+          compiledObject[className].originalFilename = path.normalize(contractFiles.find(contractFile => {
+            return normalized.indexOf(path.normalize(contractFile.originalPath)) > -1;
+          }).originalPath);
         }
       }
 

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -182,9 +182,10 @@ function compileSolc(embark, contractFiles, contractDirectories, options, callba
           compiledObject[className].userdoc = contract.userdoc;
           compiledObject[className].filename = filename;
           const normalized = path.normalize(filename);
-          compiledObject[className].originalFilename = path.normalize(contractFiles.find(contractFile => {
-            return normalized.indexOf(path.normalize(contractFile.originalPath)) > -1;
-          }).originalPath);
+          const origContract = contractFiles.find(contractFile => normalized.includes(path.normalize(contractFile.originalPath)));
+          if (origContract) {
+            compiledObject[className].originalFilename = path.normalize(origContract.originalPath);
+          }
         }
       }
 


### PR DESCRIPTION
It used the complete filename which contains `.embark`.
Not it correctly uses `contracts/contract.sol`