### PR TITLE
fix(compiler): add missing event that outputs the result

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -132,6 +132,9 @@ function compileSolc(embark, contractFiles, contractDirectories, options, callba
           logger.error(e.message || e);
           return callback(`Compiling returned an unreadable result`);
         }
+
+        embark.events.emit('contracts:compiled:solc', json);
+
         const contracts = json.contracts;
 
         // Check for errors


### PR DESCRIPTION
Was need for the cryptic plugin: https://github.com/crytic/embark-contract-info